### PR TITLE
Fix YAML error on author line

### DIFF
--- a/RPIPs/RPIP-1.md
+++ b/RPIPs/RPIP-1.md
@@ -3,7 +3,7 @@ rpip: 1
 title: RPIP Purpose and Guidelines
 status: Living
 type: Meta
-author: Mike Leach (GH: VVander | Discord: Wander#4793), Valdorff (GH: Valdorff | Discord: Val#5027)
+author: 'Mike Leach (GH: VVander | Discord: Wander#4793), Valdorff (GH: Valdorff | Discord: Val#5027)'
 discussions-to: https://dao.rocketpool.net/t/rpip-1-formalizing-protocol-changes/367
 created: 2022-03-17
 ---


### PR DESCRIPTION
This removes the error on GitHub's rendering of the page. It does not actually fix all the yaml syntax errors in the file (many of which are "line too long")...