### PR TITLE
Update RPIP-14.md

### DIFF
--- a/RPIPs/RPIP-14.md
+++ b/RPIPs/RPIP-14.md
@@ -2,7 +2,7 @@
 rpip: 14
 title: Temporary pDAO Guardian Reassignment
 description: Temporarily reassign pDAO guardian from dev team to oDAO
-author: Mike Leach AKA Wander <GH: VVander | Discord: Wander#4793>
+author: Mike Leach AKA Wander (GH - VVander, Discord - Wander#4793)
 discussions-to: https://dao.rocketpool.net/t/proposal-for-temporary-pdao-guardian-reassignment/1024
 status: Finalized
 type: Meta


### PR DESCRIPTION
Removing common syntax error in metadata. Familiarizing myself with the Repo and noticed the `:` breaking the formatting 