### PR TITLE
FOR REVIEW: Added Obsolete Status to RPIP-1, updated 11, 15, 18.

### DIFF
--- a/RPIPs/RPIP-1.md
+++ b/RPIPs/RPIP-1.md
@@ -66,7 +66,7 @@ The following is the standardization process for all RPIPs in all tracks:
 
 **Living** - A special status for RPIP that are designed to be continually updated and not reach a state of finality. This includes most notably RPIP-1.
 
-**Obsolete** - An Obsolete RPIP has been replaced, superceded or removed.
+**Obsolete** - An Obsolete RPIP has been replaced, superseded or removed.
 
 Only Final and Living RPIPs are eligible for official adoption.
 

--- a/RPIPs/RPIP-1.md
+++ b/RPIPs/RPIP-1.md
@@ -66,6 +66,8 @@ The following is the standardization process for all RPIPs in all tracks:
 
 **Living** - A special status for RPIP that are designed to be continually updated and not reach a state of finality. This includes most notably RPIP-1.
 
+**Obsolete** - An Obsolete RPIP has been replaced, superceded or removed as a result of the passage of another RPIP.
+
 Only Final and Living RPIPs are eligible for official adoption.
 
 ## What belongs in a successful RPIP?

--- a/RPIPs/RPIP-1.md
+++ b/RPIPs/RPIP-1.md
@@ -66,7 +66,7 @@ The following is the standardization process for all RPIPs in all tracks:
 
 **Living** - A special status for RPIP that are designed to be continually updated and not reach a state of finality. This includes most notably RPIP-1.
 
-**Obsolete** - An Obsolete RPIP has been replaced, superceded or removed as a result of the passage of another RPIP.
+**Obsolete** - An Obsolete RPIP has been replaced, superceded or removed.
 
 Only Final and Living RPIPs are eligible for official adoption.
 

--- a/RPIPs/RPIP-11.md
+++ b/RPIPs/RPIP-11.md
@@ -1,10 +1,10 @@
 ---
 rpip: 11
-title: (superseded) Incentive Management Committee Charter
+title: Incentive Management Committee Charter
 description: Describes what the Incentives Management Committee is for and how it will execute
 author: jasperthegovghost (@jasperthefriendlyghost), Valdorff (@Valdorff)
 discussions-to: https://dao.rocketpool.net/t/pdao-liquidity-committee-and-budget-proposal/895
-status: Final
+status: Obsolete
 type: Meta
 created: 2022-08-09
 requires: 10
@@ -14,7 +14,7 @@ vote-result: Passed
 ---
 
 ## \>\> NOTICE <<
-This RPIP has been superseded by [RPIP-20](RPIP-20.md).
+This RPIP has been made obsolete by the passage of [RPIP-20](RPIP-20.md).
 
 ## Abstract
 There is broad agreement on the need for liquidity incentives that @knoshua outlines in the

--- a/RPIPs/RPIP-15.md
+++ b/RPIPs/RPIP-15.md
@@ -1,10 +1,10 @@
 ---
 rpip: 15
-title: (superseded) Creation of Grants and Bounties Management Committee
+title: Creation of Grants and Bounties Management Committee
 description: Describes the guiding principles, selection of, operation of, and governance of the Grants and Bounties Management Committee.
 author: Calurduran (@dafuerstman), Valdorff (@Valdorff)
 discussions-to: https://dao.rocketpool.net/t/grants-and-bounties-rpip/1064
-status: Final
+status: Obsolete
 type: Meta
 created: 2022-09-18
 vote-to: https://vote.rocketpool.net/#/proposal/0x7cc60bb1bbc5f0fc061e65e1f5fc4ca23adbe9b353c6edece2ec6860b4101860
@@ -13,7 +13,7 @@ vote-result: Passed
 ---
 
 ## \>\> NOTICE <<
-This RPIP has been superseded by [RPIP-18](RPIP-18.md).
+This RPIP has been made obsolete by the passage of [RPIP-18](RPIP-18.md).
 
 ## Abstract
 RPIP-10 sets aside 30% of the pDAO budget for Grants and Bounties. The details of the mechanics of awarding grants and bounties were discussed in a forum post and in the Grants thread on the Discord Governance channel. Based on that previous work, we would like to suggest an outline for a Grants and Bounties Management Committee (hereafter GMC), including guiding principles and governance. Please see RPIP-10 for governance details that apply to all Management Committees.

--- a/RPIPs/RPIP-18.md
+++ b/RPIPs/RPIP-18.md
@@ -4,7 +4,7 @@ title: Updating of Grants Management Committee
 description: Replaces RPIP-15, which described the guiding principles, selection of, operation of, and governance of the Grants and Bounties Management Committee.
 author: Calurduran (@dafuerstman), Valdorff (@Valdorff)
 discussions-to: https://dao.rocketpool.net/t/rpip-modifying-operations-of-gmc/1448
-status: Final
+status: Obsolete
 type: Meta
 created: 2023-01-23
 vote-to: https://vote.rocketpool.net/#/proposal/0x75ca9e35555150c713e332d585b9fdf7185c9cf4222ad705459b30cf6d6bb7fb
@@ -12,6 +12,8 @@ vote-date: 2023-02-12
 vote-result: Passed
 ---
 
+## \>\> NOTICE <<
+This RPIP has been made obsolete by the passage of [RPIP-26](RPIP-26.md).
 
 ## Abstract
 RPIP-10 sets aside 30% of the pDAO budget for Grants and Bounties. The details of the mechanics of awarding grants and bounties were discussed in a forum post and in the Grants thread on the Discord Governance channel. Based on that previous work, we would like to suggest an outline for a Grants and Bounties Management Committee (hereafter GMC), including guiding principles and governance. Please see RPIP-10 for governance details that apply to all Management Committees. This RPIP supercedes RPIP-15, with changes to the committee size (enlarged to 9), the frequency of award rounds (from every-other-month to quarterly), and the removal of the requirement that a majority of the committee be made up of non-team, non-oDAO members.

--- a/RPIPs/RPIP-5.md
+++ b/RPIPs/RPIP-5.md
@@ -2,7 +2,7 @@
 rpip: 5
 title: Protocol Governance
 author: Mike Leach (@VVander) <mike@bamboofin.tech>
-status: Living
+status: Obsolete
 type: Informational
 created: 2022-03-21
 ---

--- a/RPIPs/RPIP-5.md
+++ b/RPIPs/RPIP-5.md
@@ -2,7 +2,7 @@
 rpip: 5
 title: Protocol Governance
 author: Mike Leach (@VVander) <mike@bamboofin.tech>
-status: Obsolete
+status: Living
 type: Informational
 created: 2022-03-21
 ---

--- a/_data/statuses.yaml
+++ b/_data/statuses.yaml
@@ -5,3 +5,4 @@
 - Draft
 - Stagnant
 - Withdrawn
+- Obsolete

--- a/_includes/rpiptable_full.html
+++ b/_includes/rpiptable_full.html
@@ -18,7 +18,7 @@
   }
 
   .rpiptable .status {
-    width: 3em;
+    width: 4em;
   }
   .rpiptable .rpipnum {
     width: 2em;

--- a/about_rpips.html
+++ b/about_rpips.html
@@ -16,6 +16,7 @@ title: About
   <li><strong>Stagnant</strong> - Any RPIP in Draft or Review which becomes inactive is moved to Stagnant. An RPIP may be resurrected from this state by Authors or RPIP Editors through moving it back to Draft.</li>
   <li><strong>Withdrawn</strong> - The RPIP Author(s) have withdrawn the proposed RPIP. This state has finality and can no longer be resurrected using this RPIP number. If the idea is pursued at later date, it is considered a new proposal.</li>
   <li><strong>Living</strong> - An RPIP that is designed to be continually updated and not reach a state of finality.</li>
+  <li><strong>Obsolete</strong> - An Obsolete RPIP has been replaced, superceded or removed as a result of the passage of another RPIP.
 </ul>
 
 <h2>RPIP Types</h2>

--- a/about_rpips.html
+++ b/about_rpips.html
@@ -16,7 +16,7 @@ title: About
   <li><strong>Stagnant</strong> - Any RPIP in Draft or Review which becomes inactive is moved to Stagnant. An RPIP may be resurrected from this state by Authors or RPIP Editors through moving it back to Draft.</li>
   <li><strong>Withdrawn</strong> - The RPIP Author(s) have withdrawn the proposed RPIP. This state has finality and can no longer be resurrected using this RPIP number. If the idea is pursued at later date, it is considered a new proposal.</li>
   <li><strong>Living</strong> - An RPIP that is designed to be continually updated and not reach a state of finality.</li>
-  <li><strong>Obsolete</strong> - An Obsolete RPIP has been replaced, superceded or removed.</li>
+  <li><strong>Obsolete</strong> - An Obsolete RPIP has been replaced, superseded or removed.</li>
 </ul>
 
 <h2>RPIP Types</h2>

--- a/about_rpips.html
+++ b/about_rpips.html
@@ -16,7 +16,7 @@ title: About
   <li><strong>Stagnant</strong> - Any RPIP in Draft or Review which becomes inactive is moved to Stagnant. An RPIP may be resurrected from this state by Authors or RPIP Editors through moving it back to Draft.</li>
   <li><strong>Withdrawn</strong> - The RPIP Author(s) have withdrawn the proposed RPIP. This state has finality and can no longer be resurrected using this RPIP number. If the idea is pursued at later date, it is considered a new proposal.</li>
   <li><strong>Living</strong> - An RPIP that is designed to be continually updated and not reach a state of finality.</li>
-  <li><strong>Obsolete</strong> - An Obsolete RPIP has been replaced, superceded or removed as a result of the passage of another RPIP.
+  <li><strong>Obsolete</strong> - An Obsolete RPIP has been replaced, superceded or removed.</li>
 </ul>
 
 <h2>RPIP Types</h2>


### PR DESCRIPTION
Also a minor change to the portal to accommodate a larger status field in tables. 
Staging: <https://longforwisdom.github.io/RPIPs/>

**Points to note**
* This requires modification of RPIP-1... Not sure how large or significant modifications you'll allow there absent a vote. 
* Changing language from 'superceded' to 'obsolete'. Obsolete is slightly more generally applicable and we used it at Maker, so  I went with that. If you want to keep it superceded, I can change it back,
* In practice, this prevents the Obsolete RPIPs from appearing on the 'Active' page on the portal. There are present in the 'Home', 'All', and the 'Pages by type' pages.

At one point, I added RPIP-5 to this, given that the response when we asked Val: "Is RPDAO adopted terminology?" Was "What is RPDAO?" After some consideration, I removed this again. RPIP-5 is misleading, but arguably its more misleading marking it as obsolete in its entirety. 