### PR TITLE
FOR REVIEW: More Minor RPIP Fixes

### DIFF
--- a/RPIPs/RPIP-1.md
+++ b/RPIPs/RPIP-1.md
@@ -80,7 +80,7 @@ RPIPs should be written in markdown format.
 
 **RPIP Header Preamble**
 
-Each RPIP must begin with an RFC 822 style header preamble, preceded and followed by three hyphens (---). This header is also termed “front matter” by Jekyll. The headers must appear in the following order.
+Each RPIP must begin with a header preamble, preceded and followed by three hyphens (---). This header is also termed “front matter” by Jekyll. The headers must appear in the following order.
 
 `rpip`: RPIP number (this is determined by the RPIP editor)
 

--- a/RPIPs/RPIP-1.md
+++ b/RPIPs/RPIP-1.md
@@ -10,7 +10,7 @@ created: 2022-03-17
 
 ## Summary: What is an RPIP?
 
-RPIP stands for Rocket Pool Improvement Proposal. An RPIP is a design document providing information to the Rocket Pool community or describing a new feature for Rocket Pool or its processes or environment. The precise format for RPIPs is detailed below, and [a template is located here](../rpip-template.md).
+RPIP stands for Rocket Pool Improvement Proposal. An RPIP is a design document providing information to the Rocket Pool community or describing a new feature for Rocket Pool or its processes or environment. The precise format for RPIPs is detailed below, and [a template is located here](https://github.com/rocket-pool/RPIPs/blob/main/rpip-template.md).
 
 Only RPIPs in the "Final" state are eligible for adoption and must be reviewed by editors before marked as "Final". If you want to contribute to an existing "Draft" RPIP, coordinate with the original author(s) to submit a PR. If you want to work on a new RPIP, contact any of the [editors](#rpip-editors).
 

--- a/RPIPs/RPIP-1.md
+++ b/RPIPs/RPIP-1.md
@@ -90,7 +90,7 @@ Each RPIP must begin with a header preamble, preceded and followed by three hyph
 
 `discussions-to`: The url pointing to the official discussion thread on dao.rocketpool.net
 
-`status`: Draft, Review, Final, Stagnant, Withdrawn, Living
+`status`: Draft, Review, Final, Stagnant, Withdrawn, Living, Obsolete
 
 `type`: One of Protocol, Meta, or Informational. If Protocol, please include the category (`Core` or `RPRC`).
 

--- a/RPIPs/RPIP-10.md
+++ b/RPIPs/RPIP-10.md
@@ -177,10 +177,10 @@ annually. For a theoretical run of 1 reward period (28 days), this gives  ~83.6 
 to work with. In light of parallel discussions about tokenomics changes, this amount serves as a
 conservative starting point.
 
-In addition to https://dao.rocketpool.net/t/pdao-liquidity-committee-and-budget-proposal/895, see 
-https://dao.rocketpool.net/t/pdao-budget-definition/644 for more context.
+In addition to [https://dao.rocketpool.net/t/pdao-liquidity-committee-and-budget-proposal/895](https://dao.rocketpool.net/t/pdao-liquidity-committee-and-budget-proposal/895), see 
+[https://dao.rocketpool.net/t/pdao-budget-definition/644](https://dao.rocketpool.net/t/pdao-budget-definition/644) for more context.
 
-6/1: Adjustments are being made here to support inflation changes per [RPIP-25](https://rpips.rocketpool.net/RPIPs/RPIP-25). A
+6/1: Adjustments are being made here to support inflation changes per [RPIP-25](RPIP-25.md). A
 significant one allows the pDAO to vote directly for expenses from Reserve Treasury -- this is done
 specifically with Protocol Development Funding in mind. The budget split is being updated to be
 roughly steady given the initial proposed inflation step.

--- a/about_rpips.html
+++ b/about_rpips.html
@@ -6,7 +6,7 @@ title: About
 <p>Rocket Pool Improvement Proposals (RPIPs) describe standards for Rocket Pool, including core protocol specifications, high-level governance procedures, and contract standards.
 
 <h2>Contributing</h2>
-<p>First review <a href="RPIPs/RPIP-1">RPIP-1</a>. Then clone the repository and add your RPIP to it. There is a <a href="https://github.com/rocket-pool/RPIPs/blob/master/rpip-template.md">template RPIP here</a>. Then submit a Pull Request to Rocket Pool's <a href="https://github.com/rocket-pool/RPIPs">RPIPs repository</a>.</p>
+<p>First review <a href="RPIPs/RPIP-1">RPIP-1</a>. Then clone the repository and add your RPIP to it. There is a <a href="https://github.com/rocket-pool/RPIPs/blob/main/rpip-template.md">template RPIP here</a>. Then submit a Pull Request to Rocket Pool's <a href="https://github.com/rocket-pool/RPIPs">RPIPs repository</a>.</p>
 
 <h2>RPIP Statuses</h2>
 <ul>

--- a/rpip-template.md
+++ b/rpip-template.md
@@ -1,5 +1,5 @@
 ---
-rpip: <to be assigned>
+rpip: #<to be assigned>
 title: <The RPIP title is a few words, not a complete sentence>
 description: <Description is one full (short) sentence>
 author: <a comma separated list of the author's or authors' name + GitHub username (in parenthesis), or name and email (in angle brackets).  Example, FirstName LastName (@GitHubUsername), FirstName LastName <foo@bar.com>, FirstName (@GitHubUsername) and GitHubUsername (@GitHubUsername)>


### PR DESCRIPTION
Very minor fixes that can just editor-merge.
* Fixing RPIP template link in RPIP-1
* Remove reference to RFC822, it just confuses things if you're 99% of people that don't know what this is. Also not 100% sure 822 is even the right number.
* Add hyperlinks to RPIP10 rationale.
* Change absolute links for template to point to main rather than master
* Fixed template to not break due to numerical sort if left unchanged in draft RPIP.

I've tested locally and all seems good, but I've not put it up on staging because this is minor and I'm using my staging branch for other stuff atm.