### PR TITLE
Rpl withdrawal

### DIFF
--- a/RPIPs/RPIP-31.md
+++ b/RPIPs/RPIP-31.md
@@ -61,7 +61,7 @@ https://dao.rocketpool.net/t/withdrawal-address-splitter-contract/563
 ### Staking RPL
 - As the controller of the RPL for a node, I MUST be able to stake additional RPL
   - If a node's RPL withdrawal address is unset, the call MUST come from the node's address, primary withdrawal address, or a specifically allowed address
-  - If a node's RPL withdrawal address is set, the call MUST come from the node's address, current RPL withdrawal address, or a specifically allowed address
+  - If a node's RPL withdrawal address is set, the call MUST come from the current RPL withdrawal address, or a specifically allowed address
 - As the controller of the RPL for a node, I MUST be able to control the list of specifically allowed RPL staking addresses
   - If a node's RPL withdrawal address is unset, the call MUST come from the node's address
   - If a node's RPL withdrawal address is set, the call MUST come from the current RPL withdrawal address

--- a/RPIPs/RPIP-31.md
+++ b/RPIPs/RPIP-31.md
@@ -60,9 +60,15 @@ https://dao.rocketpool.net/t/withdrawal-address-splitter-contract/563
 
 ### Staking RPL
 - As the controller of the RPL for a node, I MUST be able to stake additional RPL
-  - If a node's RPL withdrawal address is unset, the call MUST come from the node's address, or a specifically allowed address
-  - If a node's RPL withdrawal address is set, the call MUST come from the current RPL withdrawal address, or a specifically allowed address
+  - If a node's RPL withdrawal address is unset, the call MUST come from the node's address, primary withdrawal address, or a specifically allowed address
+  - If a node's RPL withdrawal address is set, the call MUST come from the node's address, current RPL withdrawal address, or a specifically allowed address
 - As the controller of the RPL for a node, I MUST be able to control the list of specifically allowed RPL staking addresses
+  - If a node's RPL withdrawal address is unset, the call MUST come from the node's address
+  - If a node's RPL withdrawal address is set, the call MUST come from the current RPL withdrawal address
+
+### Locking RPL
+- The ability to put RPL at risk via locking SHALL be initialised to disallowed
+- As the controller of the RPL for a node, I MUST be able to control whether RPL can be put at risk via locking, for example to participate in governance proposal/challenges
   - If a node's RPL withdrawal address is unset, the call MUST come from the node's address
   - If a node's RPL withdrawal address is set, the call MUST come from the current RPL withdrawal address
 

--- a/RPIPs/RPIP-31.md
+++ b/RPIPs/RPIP-31.md
@@ -66,12 +66,6 @@ https://dao.rocketpool.net/t/withdrawal-address-splitter-contract/563
   - If a node's RPL withdrawal address is unset, the call MUST come from the node's address
   - If a node's RPL withdrawal address is set, the call MUST come from the current RPL withdrawal address
 
-### Locking RPL
-- The ability to put RPL at risk via locking SHALL be initialised to disallowed
-- As the controller of the RPL for a node, I MUST be able to control whether RPL can be put at risk via locking, for example to participate in governance proposal/challenges
-  - If a node's RPL withdrawal address is unset, the call MUST come from the node's address
-  - If a node's RPL withdrawal address is set, the call MUST come from the current RPL withdrawal address
-
 ## Backwards Compatibility
 The specification as written is backwards compatible with the current withdrawal address. The behaviour is as current for node operators who do not use the new functionality.
 


### PR DESCRIPTION
Based on some devnet testing we have the following adjustment.

**Staking RPL**
The current behaviour is that the primary withdrawal address can stake RPL. The RPIP's unset condition excluded the primary withdrawal address - this would make it not backwards compatible. I suspect quite a few people use that feature.