### PR TITLE
Added portal support for community tokenomics work.

### DIFF
--- a/RPIPs/RPIP-42.md
+++ b/RPIPs/RPIP-42.md
@@ -9,7 +9,7 @@ type: Protocol
 category: Core
 created: 2024-03-08
 requires: rpip-megapools, rpip-forced-exits
-tags: tokenomics-2024
+tags: tokenomics-2024, tokenomics-content
 ---
 
 ## Abstract

--- a/RPIPs/RPIP-42.md
+++ b/RPIPs/RPIP-42.md
@@ -9,6 +9,7 @@ type: Protocol
 category: Core
 created: 2024-03-08
 requires: rpip-megapools, rpip-forced-exits
+tags: tokenomics-2024
 ---
 
 ## Abstract

--- a/RPIPs/RPIP-43.md
+++ b/RPIPs/RPIP-43.md
@@ -9,6 +9,7 @@ type: Protocol
 category: Core
 created: 2024-03-05
 requires: eip-4788
+tags: tokenomics-2024
 ---
 
 ## Abstract

--- a/RPIPs/RPIP-43.md
+++ b/RPIPs/RPIP-43.md
@@ -9,7 +9,7 @@ type: Protocol
 category: Core
 created: 2024-03-05
 requires: eip-4788
-tags: tokenomics-2024
+tags: tokenomics-2024, tokenomics-content
 ---
 
 ## Abstract

--- a/RPIPs/RPIP-44.md
+++ b/RPIPs/RPIP-44.md
@@ -9,6 +9,7 @@ type: Protocol
 category: Core
 created: 2024-03-05
 requires: eip-7002
+tags: tokenomics-2024
 ---
 
 ## Abstract

--- a/RPIPs/RPIP-44.md
+++ b/RPIPs/RPIP-44.md
@@ -9,7 +9,7 @@ type: Protocol
 category: Core
 created: 2024-03-05
 requires: eip-7002
-tags: tokenomics-2024
+tags: tokenomics-2024, tokenomics-content
 ---
 
 ## Abstract

--- a/RPIPs/RPIP-45.md
+++ b/RPIPs/RPIP-45.md
@@ -8,6 +8,7 @@ status: Draft
 type: Protocol
 category: Core
 created: 2024-03-08
+tags: tokenomics-2024
 ---
 
 ## Abstract

--- a/RPIPs/RPIP-45.md
+++ b/RPIPs/RPIP-45.md
@@ -8,7 +8,7 @@ status: Draft
 type: Protocol
 category: Core
 created: 2024-03-08
-tags: tokenomics-2024
+tags: tokenomics-2024, tokenomics-value-capture-option
 ---
 
 ## Abstract

--- a/RPIPs/RPIP-46.md
+++ b/RPIPs/RPIP-46.md
@@ -9,6 +9,7 @@ type: Protocol
 category: Core
 created: 2024-03-08
 requires: potentially rpip-45 or rpip-50
+tags: tokenomics-2024
 ---
 
 ## Abstract

--- a/RPIPs/RPIP-46.md
+++ b/RPIPs/RPIP-46.md
@@ -9,7 +9,7 @@ type: Protocol
 category: Core
 created: 2024-03-08
 requires: potentially rpip-45 or rpip-50
-tags: tokenomics-2024
+tags: tokenomics-2024, tokenomics-content
 ---
 
 ## Abstract

--- a/RPIPs/RPIP-47.md
+++ b/RPIPs/RPIP-47.md
@@ -9,6 +9,7 @@ type: Protocol
 category: Core
 created: 2024-03-08
 requires: 43
+tags: tokenomics-2024
 ---
 
 ## Abstract

--- a/RPIPs/RPIP-47.md
+++ b/RPIPs/RPIP-47.md
@@ -9,7 +9,7 @@ type: Protocol
 category: Core
 created: 2024-03-08
 requires: 43
-tags: tokenomics-2024
+tags: tokenomics-2024, tokenomics-content
 ---
 
 ## Abstract

--- a/RPIPs/RPIP-49.md
+++ b/RPIPs/RPIP-49.md
@@ -7,6 +7,7 @@ discussions-to: TBD
 status: Draft
 type: Informational
 created: 2024-03-08
+tags: tokenomics-2024
 ---
 
 ## Intro

--- a/RPIPs/RPIP-50.md
+++ b/RPIPs/RPIP-50.md
@@ -8,7 +8,7 @@ status: Draft
 type: Protocol
 category: Core
 created: 2024-03-22
-tags: tokenomics-2024
+tags: tokenomics-2024, tokenomics-value-capture-option
 ---
 
 ## Abstract

--- a/RPIPs/RPIP-50.md
+++ b/RPIPs/RPIP-50.md
@@ -8,6 +8,7 @@ status: Draft
 type: Protocol
 category: Core
 created: 2024-03-22
+tags: tokenomics-2024
 ---
 
 ## Abstract

--- a/_config.yml
+++ b/_config.yml
@@ -24,6 +24,7 @@ repository: https://github.com/rocket-pool/RPIPs/
 
 header_pages:
  - all.html
+ - tokenomics-2024.html
  - proposed.html
  - active.html
  - by_type.html

--- a/_includes/rpiptable_full.html
+++ b/_includes/rpiptable_full.html
@@ -20,8 +20,14 @@
   .rpiptable .status {
     width: 4em;
   }
+
   .rpiptable .rpipnum {
     width: 2em;
+  }
+
+  .rpiptable .rpip-table-description {
+    display: inline-block;
+    margin-top: 4px;
   }
   
   @media (max-width: 800px){
@@ -45,7 +51,7 @@
         <th class="rpipnum">RPIP</th>
         {% if include.type_col %} <th class="type">Type</th> {% endif %}
         {% if include.status_col %} <th class="status">Status</th> {% endif %}
-        <th class="title">Title</th>
+        {% if include.description %} <th class="title">Description</th> {% else %} <th class="title">Title</th>{% endif %}
         <th class="author">Author</th>
       </tr>
   </thead>
@@ -60,7 +66,8 @@
       {% endif %}
     {% endif %}
     {% if include.status_col %} <td class="status">{{page.status|xml_escape}}</td> {% endif %}
-      <td class="title"><a href="{{page.url|relative_url}}">{{page.title|xml_escape}}</a></td>
+      <td class="title"><a href="{{page.url|relative_url}}">{{page.title|xml_escape}}</a>
+      {% if include.description %}<br/><i><span class="rpip-table-description">{{page.description|xml_escape}}</i></span>{% endif %} </td>
       <td class="author">{% include authorlist.html authors=page.author %}</td>
     </tr>
   {% endfor %}

--- a/_layouts/rpip.html
+++ b/_layouts/rpip.html
@@ -98,6 +98,7 @@ layout: default
       {% when "vote-to" %} 
       {% when "vote-date" %} 
       {% when "vote-result" %} 
+      {% when "tags" %} 
       
       <!-- Ignore built-in -->
       {% when "layout" %}

--- a/tokenomics-2024.html
+++ b/tokenomics-2024.html
@@ -1,0 +1,21 @@
+---
+layout: page
+title: Tokenomics Rework
+nav-title: Tokenomics Rework
+---
+
+<div class=living>
+ℹ️ <i> These tokenomics RPIPs are currently being developed by the Rocket Pool community. Want to contribute? Check out the <a href="https://discord.com/channels/405159462932971535/1215788197842255972">Discord Thread</a>.</i>
+</div> 
+
+{% assign relevant-rpips=site.pages|where_exp:"item","item.tags contains 'tokenomics-2024'" %}
+
+<h2>Information and Overview</h2>
+
+{% assign informational-rpips=relevant-rpips|where_exp:"item","item.type == 'Informational'"| sort: "rpip" | reverse %}
+{% include rpiptable_full.html rpips=informational-rpips type_col=false status_col=true description=true%}
+
+<h2>Content RPIPs</h2>
+
+{% assign content-rpips=relevant-rpips|where_exp:"item","item.type == 'Protocol'"| sort: "rpip" | reverse %}
+{% include rpiptable_full.html rpips=content-rpips type_col=false status_col=true description=true%}

--- a/tokenomics-2024.html
+++ b/tokenomics-2024.html
@@ -5,7 +5,7 @@ nav-title: Tokenomics Rework
 ---
 
 <div class=living>
-ℹ️ <i> These tokenomics RPIPs are currently being developed by the Rocket Pool community. Want to contribute? Check out the <a href="https://discord.com/channels/405159462932971535/1215788197842255972">Discord Thread</a>.</i>
+ℹ️ <i> These tokenomics RPIPs are currently being developed by the Rocket Pool community. Want to contribute? Check out the <a href="https://discord.com/channels/405159462932971535/1215788197842255972">Discord Thread</a> and <a href="https://dao.rocketpool.net/tag/tokenomics-rework">Forum Threads</a>.</i>
 </div> 
 
 {% assign relevant-rpips=site.pages|where_exp:"item","item.tags contains 'tokenomics-2024'" %}
@@ -17,5 +17,10 @@ nav-title: Tokenomics Rework
 
 <h2>Content RPIPs</h2>
 
-{% assign content-rpips=relevant-rpips|where_exp:"item","item.type == 'Protocol'"| sort: "rpip" | reverse %}
+{% assign content-rpips=relevant-rpips|where_exp:"item","item.tags contains 'tokenomics-content'"| sort: "rpip" | reverse %}
 {% include rpiptable_full.html rpips=content-rpips type_col=false status_col=true description=true%}
+
+<h2>Optional RPIPs</h2>
+
+{% assign optional-rpips=relevant-rpips|where_exp:"item","item.tags contains 'tokenomics-value-capture-option'"| sort: "rpip" | reverse %}
+{% include rpiptable_full.html rpips=optional-rpips type_col=false status_col=true description=true%}


### PR DESCRIPTION
Staging here: <https://longforwisdom.github.io/RPIPs/tokenomics-2024>

Given the importance of the topic to more or less everyone involved in the protocol, it makes sense to treat it temporarily as a first-class citizen in the portal infrastructure. 

In the long term, this functionality can either be reverted, or generalized to existing and future RPIP sets. 