### PR TITLE
Tweak bond curves specification

### DIFF
--- a/RPIPs/RPIP-42.md
+++ b/RPIPs/RPIP-42.md
@@ -1,7 +1,7 @@
 ---
 rpip: 42
 title: Bond Curves
-description: Introduce smaller ETH bonds to improve capital efficiency for Node Operators while maintaining the security of the Rocket Pool protocol. 
+description: Introduce smaller ETH bonds to improve capital efficiency for Node Operators while maintaining the security of the Rocket Pool protocol.
 author: Valdorff (@Valdorff)
 discussions-to: TBD
 status: Draft
@@ -17,7 +17,7 @@ This proposal dramatically increases the LTV used in the protocol (loan to value
 - Enabling megapool-level penalties to mitigate/discourage MEV theft
 - Using forced exits as needed
 - Starting with lower LTV at lower total bonded ETH to mitigate/discourage MEV theft
-- Retaining sufficient bond per validator regardless of total stake to mitigate against slashing and abandonment 
+- Retaining sufficient bond per validator regardless of total stake to mitigate against slashing and abandonment
 - Providing increased capital efficiency with greater bond to encourage an NO to stake as large nodes instead of many small nodes
 
 This proposal also explicitly tries to benefit the smallest NOs in a few ways, in line with the pDAO charter values of decentralization and prioritizing Ethereum health (see [RPIP-23](./RPIP-23.md)):
@@ -31,9 +31,18 @@ The primary motivation for the introduction of smaller ETH bonds in this form is
 
 The innovation of a bond curve is motivated by the need to maintain enough stake to mitigate MEV theft, slashing penalties, and abandonment; while meeting the core goal of improved capital efficiency.
 
-This RPIP is part of a set of proposals motivated by a desire to rework Rocket Pool's tokenomics to ensure the protocol’s continued value, development, and longevity. For more details, see the supporting documentation [here](../tokenomics-explainers/001-why-rework). 
+This RPIP is part of a set of proposals motivated by a desire to rework Rocket Pool's tokenomics to ensure the protocol’s continued value, development, and longevity. For more details, see the supporting documentation [here](../tokenomics-explainers/001-why-rework).
 
 ## Specification
+
+This specification introduces the following (pDAO-configurable) settings:
+
+| Name                           | Type    | Initial Value  |
+|--------------------------------|---------|----------------|
+| `base_bond_array`              | `ETH[]` | `[4, 8]` |
+| `maximum_megapool_eth_penalty` | `ETH`   | `612` [PLACEHOLDER VALUE] |
+| `reduced_bond`                 | `ETH`   | `4`      |
+
 Array indexing in this section is zero-based.
 
 - The oDAO SHALL be able to penalize stake at the megapool level when a [Penalizable offense](#penalizable-offenses) is committed by increasing the megapool's `debt` variable defined in [RPIP-43](./RPIP-43.md/#debt-variable)
@@ -42,21 +51,18 @@ Array indexing in this section is zero-based.
   - Note that this does not replace RPIP-58, which applies to legacy minipools
 - Prior to creating a validator, there MUST be no `debt` on the megapool
   - There MAY be a convenience function to use a single ETH payment to pay off existing `debt` and create an additional validator
-- When a Node Operators creates a validator, with `i` validators in the megapool prior to adding: 
+- When a Node Operator creates a validator, with `i` validators in the megapool prior to adding:
   - If `i < base_bond_array.length`: the required `user_deposit` is the amount of additional ETH to bring the user's total bond up to `base_bond_array[i]`.
   - If `i ≥ base_bond_array.length`:, the required `user_deposit` is `reduced_bond` per validator.
-- When a Node Operators removes a validator, with `i` validators in the megapool prior to removing:
+- When a Node Operator removes a validator, with `i` validators in the megapool prior to removing:
   - If `i > base_bond_array.length`: the Node Operator share before `debt` is `reduced_bond`.
   - If `i ≤ base_bond_array.length` and `i > 1`: the Node Operator share before `debt` is the amount of ETH that would bring the user's total bond down to `base_bond_array[i-2]`.
   - If `i==1`: the Node Operator share before `debt` is the amount of ETH that would bring the user's total bond down to 0 ETH.
-- Bulk validator creation/removal functions SHALL behave the same as multiple individual transactions.
+- Any bulk validator creation/removal functions SHALL behave the same as multiple individual transactions.
 - If an NO has more total bonded ETH in their megapool than would be necessary based on the current settings (eg, `reduced_bond` is reduced), it SHALL be possible to reduce their bonded ETH and receive ETH `credit` for it
 - `credit` MUST be usable to create validators in a megapool
-- `credit` MUST be usable to mint rETH to the NO's primary withdrawal address 
-- The initial settings SHALL be:
-  - `base_bond_array`: [4, 8]
-  - `reduced_bond`: 4 ETH
-  - `maximum_megapool_eth_penalty`: 612 ETH [PLACEHOLDER VALUE]
+- `credit` MUST be usable to mint rETH to the NO's primary withdrawal address
+- The pDAO SHALL NOT be able to set `base_bond_array` to `[]`
 
 ## Specification taking effect with Saturn 2
 - Update `reduced_bond` to 1.5 ETH
@@ -79,7 +85,7 @@ This portion of the RPIP SHALL be considered Living. It may be updated by a DAO 
   - The plots below show `base_bond_array`=[4, 8] and `reduced_bond`=1.5. As we can see, MEV theft always increases yield and the impact is heightened at low commission. The reality is that we've seen very little of this type of behavior. We may have to change our approach if we see MEV theft increase or if we wish to support NO commission share under 2.5%.
   - A moderate step would be to change `base_bond_array` to a curve that reduces MEV theft advantage in the current context (commission, MEV landscape...) at the cost of user complexity, eg `[4.2, 6.8. 9.2. 11.4. 13.5. 15.5. 17.4]`
   - A larger step would be to pass EL rewards to NOs and charge them for the benefit. See eg: <https://github.com/Valdorff/rp-thoughts/tree/main/leb_safety#negative-commission-aka-assign-execution-layer-rewards-to-nos> or <https://dao.rocketpool.net/t/reimagining-large-block-theft/2146>
-  
+
 | 2.5% commission                                 | 4% commission                                |
 |-------------------------------------------------|----------------------------------------------|
 | ![img.png](../assets/rpip-42/theft_2.5pct.png)  | ![img.png](../assets/rpip-42/theft_4pct.png) |


### PR DESCRIPTION
Put the configurable settings up front in a table.
Fix some whitespace errors and other typos.