### PR TITLE
Small fixes for RPIPs 44, 59 and 60

### DIFF
--- a/RPIPs/RPIP-44.md
+++ b/RPIPs/RPIP-44.md
@@ -13,7 +13,7 @@ tags: tokenomics-2024, tokenomics-content
 ---
 
 ## Abstract
-This proposal specifies when [execution layer triggerable exits as defined in EIP-7002](https://eips.ethereum.org/EIPS/eip-7002) will be used by RP contracts. There are two enumerated use cases. The first is that the Node operator may freely request exits of their validators. The second is a keeper mechanism that allows and incentivizes any user to forcibly exit a Node Operator's validators if that Node Operator owes the protocol a threshold amount. This helps keep rETH performant and minimizes funds lost to theft.
+This proposal specifies when [execution layer triggerable exits as defined in EIP-7002](https://eips.ethereum.org/EIPS/eip-7002) will be used by RP contracts. There are two enumerated use cases. The first is that the node operator may freely request exits of their validators. The second is a keeper mechanism that allows and incentivizes any user to forcibly exit a node operator's validators if that node operator owes the protocol a threshold amount. This helps keep rETH performant and minimizes funds lost to theft.
 
 There is at least one additional use case not addressed in this RPIP, which is to exit badly-performing (eg, abandoned) validators. It is likely the pDAO will wish to supersede this RPIP to include that functionality. However, as it requires modeling and is not a critical component of the tokenomics rework, it is not being addressed at this time. For similar reasons, this RPIP does not include a keeper-based design to reward those that trigger forced exits. Please see a [historical version of RPIP-44](https://github.com/rocket-pool/RPIPs/blob/09d445accaa77f355acae1e943910ad0229a1d2e/RPIPs/RPIP-44.md) for initial but incomplete ideas to address abandonment and a keeper network.
 
@@ -21,17 +21,17 @@ There is at least one additional use case not addressed in this RPIP, which is t
 
 Execution Layer Triggerable Exits are motivated by the need to combat MEV theft by malicious Rocket Pool validators. Currently, the protocol has limited recourse against such offending validators and the proposed functionality helps to change this. It's important to continue to pursue such improvements to ensure rETH delivers the advertised APY and competes favorably with other liquid staking tokens. 
 
-A secondary motivation is to improve the Node Operator user experience, the ability to request exit of their validators via the protocol is an improvement to the current experience.
+A secondary motivation is to improve the node operator user experience, the ability to request exit of their validators via the protocol is an improvement to the current experience.
 
 This RPIP is part of a set of proposals motivated by a desire to rework Rocket Pool's tokenomics to ensure the protocol’s continued value, development, and longevity. For more details, see the supporting documentation [here](../tokenomics-explainers/001-why-rework). 
 
 ## Specification
 
 This specification SHALL be implemented in Saturn 2.
-This specification extends the specification of megapools in [RPIP-43](RPIP-43.md) with a facility for removal of validators from the megapool to be done by parties other than the Node Operator.
+This specification extends the specification of megapools in [RPIP-43](RPIP-43.md) with a facility for removal of validators from the megapool to be done by parties other than the node operator.
 
 Funds (ETH) associated with a megapool SHALL be accounted in (at least) the following categories:
-- Received Funds (`received`): Funds provided that can be used towards validator deposits; sources include deposits from the Node Operator and ETH staked on behalf of the node ([RPIP-32](RPIP-32.md))
+- Received Funds (`received`): Funds provided that can be used towards validator deposits; sources include deposits from the node operator and ETH staked on behalf of the node ([RPIP-32](RPIP-32.md))
 - Credits (`credit`): Funds already in the protocol that can be used towards validator deposits; sources include ETH already staked on the beacon chain for a migrating validator
 - Deposits (`deposited`): Funds currently staked on the beacon chain for validators associated with this megapool
 - Withdrawals (`withdrawn`): Funds received into the megapool via withdrawals from the beacon chain, including both principal and the node's share of rewards, NOT including pool stakers' share of the rewards
@@ -53,9 +53,9 @@ The exit functionality for a megapool is specified as follows:
   - This function SHALL either remove the specified validators from the megapool or revert
       - If any of the validators are still active on the beacon chain a successful call of this
         function MUST also exit those validators from the beacon chain
-  - The Node Operator SHALL be able to call this function (as implied by [RPIP-43](RPIP-43.md))
+  - The node operator SHALL be able to call this function (as implied by [RPIP-43](RPIP-43.md))
   - This function MUST be permissionlessly callable under the condition: `deficit >= exit_deficit`
-      - It MUST NOT be possible for accounts other than the Node Operator to exit more validators than needed to reduce `deficit` below `exit_deficit`
+      - It MUST NOT be possible for accounts other than the node operator to exit more validators than needed to reduce `deficit` below `exit_deficit`
 - The protocol SHALL use the `withdrawn`, `credit`, and `received` balances to pay off `debt` prior to taking action on exits
 - The protocol MAY use unstaking and staked RPL to decrease `debt` by the corresponding amount prior to taking action on exits
 

--- a/RPIPs/RPIP-59.md
+++ b/RPIPs/RPIP-59.md
@@ -74,7 +74,7 @@ ETH from the deposit pool SHALL be matched with validator deposits from queues a
 - Until ETH is assigned to a validator, it SHALL be possible to exit the queue and receive ETH `credit` for it
 
 #### Social Assignments
-- The deposit.assign.socialised.maximum setting SHALL be set to 0
+- The `deposit.assign.socialised.maximum` setting SHALL be set to 0
 
 #### Initial Settings
 - The initial settings SHALL be:

--- a/RPIPs/RPIP-59.md
+++ b/RPIPs/RPIP-59.md
@@ -1,7 +1,7 @@
 ---
 rpip: 59
 title: Deposit Mechanics
-description: Describes the mechanics of Node Operator deposits and validator creation, including standard and express queues.
+description: Describes the mechanics of node operator deposits and validator creation, including standard and express queues.
 author: Valdorff (@Valdorff), knoshua (@knoshua)
 discussions-to: TBD
 status: Draft
@@ -14,7 +14,7 @@ tags: tokenomics-2024, tokenomics-content
 
 ## Abstract
 
-Defines the queue structures that govern validator deposits and the overall deposit process for Rocket Pool node operators. The standard and express queue structures give mild priority to existing Rocket Pool Node Operators and initial Node Operator deposits through a ticket system.
+Defines the queue structures that govern validator deposits and the overall deposit process for Rocket Pool node operators. The standard and express queue structures give mild priority to existing Rocket Pool node operators and initial node operator deposits through a ticket system.
 
 This proposal also changes the deposit mechanics: In case of a queue, the initial stake transaction happens only once ETH is assigned. This makes it possible to exit from the queue and receive ETH credit up until the validator is dequeued.
 
@@ -47,7 +47,7 @@ ETH from the deposit pool SHALL be matched with validator deposits from queues a
 - A node operator MUST take 2 actions to start a validator: `deposit` and `stake`
 
 #### `deposit` Transaction
-- `deposit` SHALL place the Node Operator ETH in the deposit pool (where it can be used in validators as needed) and place the validator in a queue as described [above](#deposit-queue-specification)
+- `deposit` SHALL place the node operator ETH in the deposit pool (where it can be used in validators as needed) and place the validator in a queue as described [above](#deposit-queue-specification)
 - The following values for the validator SHALL be stored on chain:
     - the public key of the validator
     - the BLS signature over the public key, the withdrawal credentials (the megapool address of the node operator), and the amount (1 ETH) as required by the deposit contract
@@ -87,13 +87,13 @@ ETH from the deposit pool SHALL be matched with validator deposits from queues a
 - The express queue is meant to favor (a) small NOs and (b) existing NOs. The end goal in both cases is to support multiple values enshrined in [RPIP-23](RPIP-23.md) (the pDAO charter): decentralization, protocol safety, and the health of the Ethereum network.
   - The `express_queue_tickets_base_provision` is enough to get started, and currently matches the length of `base_bond_array`
   - The tickets from `(bonded ETH in legacy minipools)/4` are enough to fully migrate to 4-ETH deposits during Saturn 1 using the express queue OR to partly migrate to 1.5-ETH deposits after Saturn 2
-  - Tickets may be used or not at an NO's discretion and do not expire! This is because a Node Operator joining during a time when we don't have an NO queue is helping fill a protocol need, and it therefore doesn't make sense for us to require them to incur the additional cost of using up a ticket. This means they get to keep their express queue benefit for a later time if they wish.
-- Validators with `base_bond` deposits are prioritized to promote decentralization; new or smaller Node Operators can get up to `base_bond_array.length` validators launched ahead of larger Node Operators adding `reduced_bond` validators.
+  - Tickets may be used or not at an NO's discretion and do not expire! This is because a node operator joining during a time when we don't have an NO queue is helping fill a protocol need, and it therefore doesn't make sense for us to require them to incur the additional cost of using up a ticket. This means they get to keep their express queue benefit for a later time if they wish.
+- Validators with `base_bond` deposits are prioritized to promote decentralization; new or smaller node operators can get up to `base_bond_array.length` validators launched ahead of larger node operators adding `reduced_bond` validators.
 
 ### Deposit Mechanics
 - `prestake` is moved back from `deposit` to assignment to allow for exiting of the queue
 - To allow anyone to execute `prestake`, the validator specific data is stored 
-- Since adding `prestake` to assignments potentially  increases gas cost for rETH deposits, social assignments are deactivated. Node Operators will be able to assign to themselves when at the front of the queue. Additionally, the pDAO may fund keepers that execute assignments automatically. 
+- Since adding `prestake` to assignments potentially  increases gas cost for rETH deposits, social assignments are deactivated. node operators will be able to assign to themselves when at the front of the queue. Additionally, the pDAO may fund keepers that execute assignments automatically. 
 
 ## Security Considerations
 

--- a/RPIPs/RPIP-59.md
+++ b/RPIPs/RPIP-59.md
@@ -98,7 +98,7 @@ ETH from the deposit pool SHALL be matched with validator deposits from queues a
 ## Security Considerations
 
 ### Deposit Queue
-- `express_queue_tickets_base_provision` means that the queue favors sock puppets. It's important to disincentivize small sock puppets as they get higher vote power than desired and would most damage the protocol if they took part in MEV theft ([RPIP-42 security considerations](RPIP-42.md#security-considerations) discusses this further)
+- `express_queue_tickets_base_provision` means that the queue favors sock puppets. It's important to disincentivize small sock puppets as they get higher vote power than desired and would most damage the protocol if they took part in MEV theft ([RPIP-42 security considerations](RPIP-42.md#security-considerations) discusses this further).
   - Immediately with Saturn 1 there is a drawback to sock puppets in the form of increased gas cost. They need to deploy multiple megapool smart contract instances and they need multiple transactions to claim beacon chain rewards.
   - With Saturn 2, we update `reduced_bond` to 1.5 ETH, which further disincentivizes sock puppets
 - Setting `express_queue_rate` to 0 disables the express queue and people currently in it are stuck indefinitely. Similarly, setting `express_queue_rate` to a very high value effectively disables the `standard_queue`. However, node operators would be able to exit the queue for `credit`.

--- a/RPIPs/RPIP-60.md
+++ b/RPIPs/RPIP-60.md
@@ -55,7 +55,7 @@ Any upgrade will have `proposal.vote.delay.time` (currently 1 week) and `upgrade
 ### Upgrade Delay
 - Emergency response settings changes should be taken directly by the security council (see [RPIP-33](RPIP-33.md)) rather than use the regular governance process
 - The fastest possible upgrade speed is significantly slowed from the previous state. It used to take `proposal.vote.delay.time` (currently 1 week) and will now take an additional `upgrade_delay` (initially set to 1 week). This means that important hotfixes could take longer. It may also mean that emergency pauses (eg, disabling rETH deposits) could last longer until a hotfix takes effect.
-- The fastest possible upgrade speed is now faster than the RPL `unstaking_period` defined in [RPIP-30](RPIP-30.md), and there are edge cases where it may be faster than the time it takes to exit ETH (if the validator exit queue is very full).
+- The fastest possible upgrade speed is now faster than the RPL `unstaking_period` defined in [RPIP-30](RPIP-30.md), and there are edge cases where it may be faster than the time it takes to exit ETH (if the validator exit queue is very full)
 
 ### Security Council Veto
 - The security council veto means it would require both a rogue oDAO and a rogue security council to pass a corrupt proposal

--- a/RPIPs/RPIP-60.md
+++ b/RPIPs/RPIP-60.md
@@ -41,21 +41,6 @@ This RPIP is part of a set of proposals motivated by a desire to rework Rocket P
 - If possible, the Veto Explanation Document SHOULD suggest alternative similar-but-non-damaging upgrades that could be considered
 - If this veto power is abused, the pDAO SHOULD discuss replacing the members of the security council
 
-## Security Considerations
-
-### Upgrade Delay
-- Emergency response settings changes should be taken directly by the security council (see [RPIP-33](RPIP-33.md)) rather than use the regular governance process.
-- The fastest possible upgrade speed is significantly slowed from the previous state. It used to take `proposal.vote.delay.time` (currently 1 week) and will now take an additional `upgrade_delay` (initially set to 3 weeks). This means that important hotfixes could take a lot longer. It may also mean that emergency pauses (eg, disabling rETH deposits) could last longer until a hotfix takes effect.
-- The fastest possible upgrade speed exactly matches the RPL `unstaking_period` defined in [RPIP-30](RPIP-30.md). 
-
-### Security Council Veto
-- The security council veto means it would require both a rogue oDAO and a rogue security council to pass a corrupt proposal.
-- The security council veto means that a rogue security council could block a valid proposal.
-  - This is mitigated by the pDAO's ability to replace the security council. While a valid proposal could be blocked once, it could not be blocked indefinitely.
-- The veto process can itself be modified by contract upgrades. However, if a corrupt proposal tries to change the veto process, that can be defended against by using the veto process.
-- The security council veto means that if pDAO governance were captured, protocol upgrades could be stopped at will (by installing a compromised security council). The oDAO would be unable to pass any contract upgrades (without the approval of the compromised security council), and the only way back would be to recapture pDAO governance. While this means there is a real tradeoff, this "inability to upgrade" is seen as less problematic than the "ability to pass any upgrade" that a rogue oDAO would have without the veto.
-- The quorum for this veto is lower than for security council proposals (controlled by `rocketDAOProtocolSettingsSecurity.members.quorum`). This is intended to provide additional resilience to, eg, a rogue oDAO that attempts to bribe a security council into not vetoing a corrupt proposal (as fewer bribe-resistant members are needed). This sort of interaction doesn't exist for normal security council proposals, which is what leads to a different desired threshold. 
-
 ## Rationale
 **Veto Explanation Document**  
 The explanation document is a mechanism intended to help the pDAO hold the security council to account for their decision-making around vetos. It gives more information as to the reasoning behind a veto decision and should help to inform pDAO decision-making post-veto. In an ideal world, the document accompanies the veto. The 24-hour grace period is intended to cover situations in which the security council must act within a limited time window.
@@ -63,7 +48,22 @@ The explanation document is a mechanism intended to help the pDAO hold the secur
 **Upgrade Delay Setting**  
 Due to the considerations around slowing down hotfixes [described above](#security-considerations), the initial upgrade delay setting is attempting to be the smallest that allows "enough" time for participants to exit the system ahead of a proposal if they deem that appropriate.
 
-Any upgrade will have `proposal.vote.delay.time` (currently 1 week) and `upgrade_delay` (initially set to 3 weeks). This is _just_ enough to match the RPL `unstaking_period` (currently 28 days). In normal circumstances, there will be more time available to exit. There is a leadup period to the sentiment poll (currently at least 1 week), there is a pDAO vote period (currently at least 2 weeks), there's a human action required to raise the oDAO proposal, and there are many human actions to place oDAO votes after `proposal.vote.delay.time`. These delays should provide enough breathing room to allow participants to exit ahead of a proposal despite the 28-day unstaking period.
+Any upgrade will have `proposal.vote.delay.time` (currently 1 week) and `upgrade_delay` (initially set to 1 week). This isn't enough to match the RPL `unstaking_period` (currently 28 days). In normal circumstances, there will be more time available to exit. There is a leadup period to the sentiment poll (currently at least 1 week), there is a pDAO vote period (currently at least 2 weeks), there's a human action required to raise the oDAO proposal, and there are many human actions to place oDAO votes after `proposal.vote.delay.time`. These delays should provide enough breathing room to allow participants to exit ahead of a proposal despite the 28-day unstaking period.
+
+## Security Considerations
+
+### Upgrade Delay
+- Emergency response settings changes should be taken directly by the security council (see [RPIP-33](RPIP-33.md)) rather than use the regular governance process
+- The fastest possible upgrade speed is significantly slowed from the previous state. It used to take `proposal.vote.delay.time` (currently 1 week) and will now take an additional `upgrade_delay` (initially set to 1 weeks). This means that important hotfixes could take a lot longer. It may also mean that emergency pauses (eg, disabling rETH deposits) could last longer until a hotfix takes effect.
+- The fastest possible upgrade speed is still shorter than the RPL `unstaking_period` defined in [RPIP-30](RPIP-30.md) 
+
+### Security Council Veto
+- The security council veto means it would require both a rogue oDAO and a rogue security council to pass a corrupt proposal
+- The security council veto means that a rogue security council could block a valid proposal
+  - This is mitigated by the pDAO's ability to replace the security council. While a valid proposal could be blocked once, it could not be blocked indefinitely
+- The veto process can itself be modified by contract upgrades. However, if a corrupt proposal tries to change the veto process, that can be defended against by using the veto process.
+- The security council veto means that if pDAO governance were captured, protocol upgrades could be stopped at will (by installing a compromised security council). The oDAO would be unable to pass any contract upgrades (without the approval of the compromised security council), and the only way back would be to recapture pDAO governance. While this means there is a real tradeoff, this "inability to upgrade" is seen as less problematic than the "ability to pass any upgrade" that a rogue oDAO would have without the veto.
+- The quorum for this veto is lower than for security council proposals (controlled by `rocketDAOProtocolSettingsSecurity.members.quorum`). This is intended to provide additional resilience to, eg, a rogue oDAO that attempts to bribe a security council into not vetoing a corrupt proposal (as fewer bribe-resistant members are needed). This sort of interaction doesn't exist for normal security council proposals, which is what leads to a different desired threshold. 
 
 ## Copyright
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/RPIPs/RPIP-60.md
+++ b/RPIPs/RPIP-60.md
@@ -48,14 +48,14 @@ The explanation document is a mechanism intended to help the pDAO hold the secur
 **Upgrade Delay Setting**  
 Due to the considerations around slowing down hotfixes [described above](#security-considerations), the initial upgrade delay setting is attempting to be the smallest that allows "enough" time for participants to exit the system ahead of a proposal if they deem that appropriate.
 
-Any upgrade will have `proposal.vote.delay.time` (currently 1 week) and `upgrade_delay` (initially set to 1 week). This isn't enough to match the RPL `unstaking_period` (currently 28 days). In normal circumstances, there will be more time available to exit. There is a leadup period to the sentiment poll (currently at least 1 week), there is a pDAO vote period (currently at least 2 weeks), there's a human action required to raise the oDAO proposal, and there are many human actions to place oDAO votes after `proposal.vote.delay.time`. These delays should provide enough breathing room to allow participants to exit ahead of a proposal despite the 28-day unstaking period.
+Any upgrade will have `proposal.vote.delay.time` (currently 1 week) and `upgrade_delay` (initially set to 1 week). This is likely enough time to exit validators and withdraw ETH (barring an extreme exit queue). In normal circumstances, there will be more time available to exit. There is a leadup period to the sentiment poll (currently at least 1 week), there is a pDAO vote period (currently at least 2 weeks), there's often dev time (which can be large), there's a human action required to raise the oDAO proposal, and there are many human actions to place oDAO votes after `proposal.vote.delay.time`. These delays should provide significant breathing room to allow participants to exit their ETH positions ahead of a proposal, and may even provide enough time to exit RPL positions despite the 28-day unstaking period. RPL exiting was not heavily prioritized because it's unclear how a severely damaging protocol change wouldn't be priced in by 28 days anyhow.
 
 ## Security Considerations
 
 ### Upgrade Delay
 - Emergency response settings changes should be taken directly by the security council (see [RPIP-33](RPIP-33.md)) rather than use the regular governance process
-- The fastest possible upgrade speed is significantly slowed from the previous state. It used to take `proposal.vote.delay.time` (currently 1 week) and will now take an additional `upgrade_delay` (initially set to 1 weeks). This means that important hotfixes could take a lot longer. It may also mean that emergency pauses (eg, disabling rETH deposits) could last longer until a hotfix takes effect.
-- The fastest possible upgrade speed is still shorter than the RPL `unstaking_period` defined in [RPIP-30](RPIP-30.md) 
+- The fastest possible upgrade speed is significantly slowed from the previous state. It used to take `proposal.vote.delay.time` (currently 1 week) and will now take an additional `upgrade_delay` (initially set to 1 week). This means that important hotfixes could take longer. It may also mean that emergency pauses (eg, disabling rETH deposits) could last longer until a hotfix takes effect.
+- The fastest possible upgrade speed is now faster than the RPL `unstaking_period` defined in [RPIP-30](RPIP-30.md), and there are edge cases where it may be faster than the time it takes to exit ETH (if the validator exit queue is very full).
 
 ### Security Council Veto
 - The security council veto means it would require both a rogue oDAO and a rogue security council to pass a corrupt proposal


### PR DESCRIPTION
- capitalization: node operator
- punctuation
- RPIP-60: Rationale and Security Considerations updated to account for initial `upgrade_delay`of 1 week
- RPIP-60: swap Rationale and Security Considerations section