### PR TITLE
Final fixes for RPIP-43

### DIFF
--- a/RPIPs/RPIP-43.md
+++ b/RPIPs/RPIP-43.md
@@ -46,7 +46,9 @@ validators deposited after this RPIP is implemented.
 Megapools keep track of the set of validators associated with them and the
 status of each validator. The possible statuses for validators associated with
 megapools SHALL include at least the following:
-  - Prestaked: a node operator has added this validator to their megapool, but
+  - Initialized: a node operator has added this validator to their megapool, but
+               the validator has not yet been assigned ETH from the deposit pool
+  - Prestaked: this validator has been assgined ETH and the `prestake` transaction has been executed, but
                the validator has not yet had its full activation balance
                deposited to the beacon chain
   - Staked:    this validator has been added to the megapool and is in the
@@ -61,7 +63,7 @@ Node operators can manage the set of validators in their megapool:
        credentials to the megapool address
 - New and existing validators' withdrawal credentials MUST be checked to
   correctly refer to the megapool address
-     - The check MAY occur after the validator is added initially as Prestaked
+     - The check MAY occur after the validator enters the Prestaked status
 - A node operator SHALL be able to remove exited validators from their megapool
 
 ### `debt` Variable

--- a/RPIPs/RPIP-43.md
+++ b/RPIPs/RPIP-43.md
@@ -21,7 +21,7 @@ Megapools are motivated by several desires; to lower ongoing costs, to lower the
 
 ETH-only node operation is motivated by a desire to support growth in the demand for rETH and further lower the barrier to entry to Rocket Pool.
 
-This RPIP is part of a set of proposals motivated by a desire to rework Rocket Pool's tokenomics to ensure the protocol’s continued value, development, and longevity. For more details, see the supporting documentation [here](../tokenomics-explainers/001-why-rework). 
+This RPIP is part of a set of proposals motivated by a desire to rework Rocket Pool's tokenomics to ensure the protocol’s continued value, development, and longevity. For more details, see the supporting documentation [here](../tokenomics-explainers/001-why-rework.md). 
 
 ## Specification
 

--- a/RPIPs/RPIP-43.md
+++ b/RPIPs/RPIP-43.md
@@ -94,10 +94,8 @@ into shares is defined in [RPIP-46](RPIP-46.md).
 - There SHALL be a reward distribution function in the megapool
   - For this section, we define `borrowed_portion` as the megapool's `borrowed_eth / (bonded_eth + borrowed_eth)`
   - When called, `reth_share * borrowed_portion` of rewards SHALL be sent to the rETH contract
-  - When called, `voter_share * borrowed_portion` of rewards SHALL be sent to a merkle rewards
+  - When called, `(voter_share - node_operator_commission_share_council_adder) * borrowed_portion` of rewards SHALL be sent to a merkle rewards
     distributor contract
-  - When called, `surplus_share * borrowed_portion` of rewards SHALL be sent to the appropriate
-    surplus disposition contract
   - If `debt` exists when called, the remaining rewards SHALL first be used to pay off `debt`
   - When called, any remaining rewards SHALL then be held in the megapool as unclaimed node operator funds 
   - This function SHALL be permissionless

--- a/RPIPs/RPIP-43.md
+++ b/RPIPs/RPIP-43.md
@@ -48,7 +48,7 @@ status of each validator. The possible statuses for validators associated with
 megapools SHALL include at least the following:
   - Initialized: a node operator has added this validator to their megapool, but
                the validator has not yet been assigned ETH from the deposit pool
-  - Prestaked: this validator has been assgined ETH and the `prestake` transaction has been executed, but
+  - Prestaked: this validator has been assigned ETH and the `prestake` transaction has been executed, but
                the validator has not yet had its full activation balance
                deposited to the beacon chain
   - Staked:    this validator has been added to the megapool and is in the

--- a/RPIPs/RPIP-43.md
+++ b/RPIPs/RPIP-43.md
@@ -51,8 +51,7 @@ megapools SHALL include at least the following:
                deposited to the beacon chain
   - Staked:    this validator has been added to the megapool and is in the
                `pending_queued` or later state on the beacon chain
-  - Dissolved: this validator's withdrawal credentials have been discovered to
-               be incorrect (ie, not this megapool)
+  - Dissolved: the `stake` transaction for this validator wasn't executed in time (see [RPIP-44](RPIP-59.md))
 
 Node operators can manage the set of validators in their megapool:
 
@@ -61,8 +60,7 @@ Node operators can manage the set of validators in their megapool:
      - Note that this would involve updating the validators' BLS withdrawal
        credentials to the megapool address
 - New and existing validators' withdrawal credentials MUST be checked to
-  correctly refer to the megapool address, with the validator status set to
-  Dissolved if the check fails
+  correctly refer to the megapool address
      - The check MAY occur after the validator is added initially as Prestaked
 - A node operator SHALL be able to remove exited validators from their megapool
 

--- a/RPIPs/RPIP-44.md
+++ b/RPIPs/RPIP-44.md
@@ -23,7 +23,7 @@ Execution Layer Triggerable Exits are motivated by the need to combat MEV theft 
 
 A secondary motivation is to improve the node operator user experience, the ability to request exit of their validators via the protocol is an improvement to the current experience.
 
-This RPIP is part of a set of proposals motivated by a desire to rework Rocket Pool's tokenomics to ensure the protocol’s continued value, development, and longevity. For more details, see the supporting documentation [here](../tokenomics-explainers/001-why-rework). 
+This RPIP is part of a set of proposals motivated by a desire to rework Rocket Pool's tokenomics to ensure the protocol’s continued value, development, and longevity. For more details, see the supporting documentation [here](../tokenomics-explainers/001-why-rework.md). 
 
 ## Specification
 

--- a/RPIPs/RPIP-59.md
+++ b/RPIPs/RPIP-59.md
@@ -22,7 +22,7 @@ This proposal also changes the deposit mechanics: In case of a queue, the initia
 
 These changes are intended to strengthen the protocol by 1) rewarding existing NOs who have shown amazing loyalty to the protocol 2) minimizing governance churn from RPL staked NOs being stuck in queue without voting privileges 3) prioritizing initial deposits to allow easier onboarding of people trialing RP before deciding to migrate in full 4) maximizing Rocket Pool's major decentralization advantage over other LSTs - a huge set of small NOs.
 
-This RPIP is part of a set of proposals motivated by a desire to rework Rocket Pool's tokenomics to ensure the protocol’s continued value, development, and longevity. For more details, see the supporting documentation [here](../tokenomics-explainers/001-why-rework). 
+This RPIP is part of a set of proposals motivated by a desire to rework Rocket Pool's tokenomics to ensure the protocol’s continued value, development, and longevity. For more details, see the supporting documentation [here](../tokenomics-explainers/001-why-rework.md). 
 
 ## Specification
 

--- a/RPIPs/RPIP-60.md
+++ b/RPIPs/RPIP-60.md
@@ -22,7 +22,7 @@ This RPIP is motivated by the desire to protect participants in Rocket Pool as b
 
 The security council veto comes from a desire to have a last-resort layer of security against obviously harmful actions.
 
-This RPIP is part of a set of proposals motivated by a desire to rework Rocket Pool's tokenomics to ensure the protocol’s continued value, development, and longevity. For more details, see the supporting documentation [here](../tokenomics-explainers/001-why-rework). 
+This RPIP is part of a set of proposals motivated by a desire to rework Rocket Pool's tokenomics to ensure the protocol’s continued value, development, and longevity. For more details, see the supporting documentation [here](../tokenomics-explainers/001-why-rework.md). 
 
 ## Specification
 


### PR DESCRIPTION
- correct definition for Dissolved status
- remove reference to Dissolved in relation to scrubbing
- add Initialized status for validators in queue 
- remove reference to `surplus_share`
- adjust `voter_share` with security council adder