### PR TITLE
Reward Tree v10: Errata and Clarifications

### DIFF
--- a/assets/rpip-62/rewards-calculation-spec.md
+++ b/assets/rpip-62/rewards-calculation-spec.md
@@ -638,10 +638,11 @@ For each slot in the reward interval, get the list of validator withdrawals (e.g
 ```go
 minipoolWithdrawals[address] += amount
 ```
-Then, get `startBcBalance` and `endBcBalance` for each minipool by querying for validator balances at `rewardStartBcSlot` and `rewardEndBcSlot`, respectively (e.g. `/eth/v1/beacon/states/<slotIndex>/validator_balances`). Use them to calculate the minipool's eligible consensus income and corresponding bonus. In case of negative consensus income, award no bonus.
+Use the cumulative withdrawals to calculate the minipool's eligible consensus income and corresponding bonus.
 ```go
-consensusIncome := endBcBalance + minipoolWithdrawals[minipool.Address] - max(32 Eth, startBcBalance)
-bonusShare := (fee - baseFee) * (32 Eth - bond) / 32 Eth
+consensusIncome := minipoolWithdrawals[minipool.Address]
+bonusFee := getTotalFee(currentFee, currentBond) - currentFee
+bonusShare := bonusFee * (32 Eth - currentBond) / 32 Eth
 minipoolBonus := max(0, consensusIncome * bonusShare / 1 Eth)
 ```
 Add the minipool's bonus to the totals.

--- a/assets/rpip-62/rewards-calculation-spec.md
+++ b/assets/rpip-62/rewards-calculation-spec.md
@@ -571,10 +571,10 @@ When a successful attestation is found, calculate the `minipoolScore` awarded to
     }
     ```
 3. Configure `saturnOneInterval` to be the reward period in which the Saturn 1 upgrade contract was executed. If this has not happened yet, use an interval far into the future (e.g. 1e18 or the data type's maximum value if bounded). In detail, `rocketUpgradeOneDotFour.executed()` (signature `0x31a38c89`) shall act as source of truth for upgrade execution. Non-existence of the contract or function should be considered equivalent to a return value of `false`, i.e. not yet executed.
-4. Get the parent node's `percentOfBorrowedETH` (see the  [getNodeWeight section](#getnodeweight)) and adjust the fee.
+4. Get the parent node's `percentOfBorrowedETH` (see the  [getNodeWeight section](#getnodeweight)) and adjust the fee. Define this calculation as `getTotalFee(minipoolFee, minipoolBond)` with `fee` as the return value for later reference.
     ```go
-    fee := baseFee
-    isEligibleBond := bond < 16 Eth
+    fee := minipoolFee
+    isEligibleBond := minipoolBond < 16 Eth
     isEligibleInterval := (currentIndex - 4) < saturnOneInterval
     if isEligibleBond && isEligibleInterval {
         fee = max(fee, 0.10 Eth + (0.04 Eth * min(10 Eth, percentOfBorrowedETH) / 10 Eth))
@@ -582,7 +582,9 @@ When a successful attestation is found, calculate the `minipoolScore` awarded to
     ```
 5. Calculate the `minipoolScore` using the minipool's bond amount and node fee:
     ```go
-    minipoolScore := (1e18 - fee) * bond / 32e18 + fee // The "ideal" fractional amount of ETH awarded to the NO for this attestation, out of 1
+    scoreFee := getTotalFee(baseFee, bond)
+    // The "ideal" fractional amount of ETH awarded to the NO for this attestation, out of 1
+    minipoolScore := (1e18 - scoreFee) * bond / 32e18 + scoreFee
     ```
 6. Add `minipoolScore` to the minipool's running total, and the cumulative total for all minipools:
     ```go

--- a/assets/rpip-62/rewards-calculation-spec.md
+++ b/assets/rpip-62/rewards-calculation-spec.md
@@ -634,7 +634,7 @@ If the range is empty (`eligibleStartTime >= eligibleEndTime`), award a `minipoo
 rewardStartBcSlot := math.Ceil((eligibleStartTime - genesisTime) / secondsPerSlot)
 rewardEndBcSlot := math.Ceil((eligibleEndTime - genesisTime) / secondsPerSlot)
 ```
-For each slot in the reward interval, get the list of validator withdrawals (e.g. `/eth/v2/beacon/blocks/<slotIndex>`). Note the `address` and `amount` for withdrawals that correspond to an eligible minipool and add them to the minipool's total. Withdrawals that do not occur in `(rewardStartBcSlot, rewardEndBcSlot]` should be ignored. If the slot is ahead of the validator's `withdrawable_epoch` (e.g. `/eth/v1/beacon/states/<targetBcSlot>/validators?id=0x<pubkey>`), credit the full withdrawal amount.
+For each slot in the reward interval, get the list of validator withdrawals (e.g. `/eth/v2/beacon/blocks/<slotIndex>`). Note the `address` and `amount` for withdrawals that correspond to an eligible minipool and add them to the minipool's total. Withdrawals that do not occur in `(rewardStartBcSlot, rewardEndBcSlot]` should be ignored. If the slot is before the first slot of the validator's `withdrawable_epoch` (e.g. `/eth/v1/beacon/states/<targetBcSlot>/validators?id=0x<pubkey>`), credit the full withdrawal amount.
 ```go
 minipoolWithdrawals[address] += amount
 ```

--- a/assets/rpip-62/rewards-calculation-spec.md
+++ b/assets/rpip-62/rewards-calculation-spec.md
@@ -622,10 +622,13 @@ First, define `totalConsensusBonus`, which will serve to store the cumulative to
 ```go
 totalConsensusBonus := 0
 ```
-For each smoothing pool eligible minipool (see [Node Eligibility](#node-eligibility)), define the slot limits within which the reward bonus is to be paid out.
+For each smoothing pool eligible minipool (see [Node Eligibility](#node-eligibility)), define the time range within which the reward bonus is to be paid out.
 ```go
 eligibleStartTime := max(startTime, statusTime, optInTime, lastReduceTime)
 eligibleEndTime := min(endTime, optOutTime)
+```
+If the range is empty (`eligibleStartTime >= eligibleEndTime`), award a `minipoolBonus` of `0`. Otherwise, define slot limits for the bonus calculation.
+```
 rewardStartBcSlot := math.Ceil((eligibleStartTime - genesisTime) / secondsPerSlot)
 rewardEndBcSlot := math.Ceil((eligibleEndTime - genesisTime) / secondsPerSlot)
 ```

--- a/assets/rpip-62/rewards-calculation-spec.md
+++ b/assets/rpip-62/rewards-calculation-spec.md
@@ -634,9 +634,13 @@ If the range is empty (`eligibleStartTime >= eligibleEndTime`), award a `minipoo
 rewardStartBcSlot := math.Ceil((eligibleStartTime - genesisTime) / secondsPerSlot)
 rewardEndBcSlot := math.Ceil((eligibleEndTime - genesisTime) / secondsPerSlot)
 ```
-For each slot in the reward interval, get the list of validator withdrawals (e.g. `/eth/v2/beacon/blocks/<slotIndex>`). Note the `address` and `amount` for withdrawals that correspond to an eligible minipool and add them to the minipool's total. Withdrawals that do not occur in `(rewardStartBcSlot, rewardEndBcSlot]` should be ignored.
+For each slot in the reward interval, get the list of validator withdrawals (e.g. `/eth/v2/beacon/blocks/<slotIndex>`). Note the `address` and `amount` for withdrawals that correspond to an eligible minipool and add them to the minipool's total. Withdrawals that do not occur in `(rewardStartBcSlot, rewardEndBcSlot]` should be ignored. If the slot is ahead of the validator's `withdrawable_epoch` (e.g. `/eth/v1/beacon/states/<targetBcSlot>/validators?id=0x<pubkey>`), credit the full withdrawal amount.
 ```go
 minipoolWithdrawals[address] += amount
+```
+Otherwise, only credit what is in excess of the maximum effective balance.
+```go
+minipoolWithdrawals[address] += max(0, amount - 32 Eth)
 ```
 Use the cumulative withdrawals to calculate the minipool's eligible consensus income and corresponding bonus.
 ```go


### PR DESCRIPTION
- changes `interval` variable name to `currentIndex` to match previous reference to the reward interval 
- specifically states that bonus commission eligibility is also subject to standard smoothing pool eligibility criteria 
- specifically states that no bonus should be awarded if `eligibleStartTime`  ≥ `eligibleEndTime`
- removes `getMinipoolBonus` function to simplify the spec as it was only called once
- changes `getTotalNodeFee` arguments from `baseFee, percentOfBorrowedETH` to `minipoolFee, minipoolBond` 
- fixes typo: `totalEthForMinipool` -> `totalEthForMinipools`
- removes beacon balance queries from consensus income calculation due to performance issues