### PR TITLE
Update GMC Target Hours to 15

### DIFF
--- a/RPIPs/RPIP-41.md
+++ b/RPIPs/RPIP-41.md
@@ -74,7 +74,7 @@ Future committees SHOULD be added to this RPIP and members SHOULD expect to rece
 
 | Date                       | Target Member Count | Target Hours        | Target Monthly Stipend Budget |
 |----------------------------|---------------------|---------------------|------------------------------|
-| 2024-03-04 (RPIP Authored) |                   9 |                  13 |                    $3,510.00 |
+| 2025-02-13 (Voted Change)  |                   9 |                  15 |                    $4,050.00 |
 
 #### Incentives Management Committee
 


### PR DESCRIPTION
Forum post on January 13, 2025 - https://dao.rocketpool.net/t/gmc-increasing-target-member-hours-from-13-to-15/3476

Internal vote passed unanimously on January 14, 2025. (RPIP Authors Ken, and ramana voted.)