### PR TITLE
RPIP-50.md: fixed dead link

### DIFF
--- a/RPIPs/RPIP-50.md
+++ b/RPIPs/RPIP-50.md
@@ -43,7 +43,7 @@ This RPIP is part of a set of proposals motivated by a desire to rework Rocket P
 - The pool's swap fee is set on the higher end to discourage thrashing and low-value arbitrage
 - The deposit cooldown is set to prevent multiple distributions in quick succession purely to enable arbitrage
 - The pool is most vulnerable to value extraction attacks when `lp_deposit_threshold` is large relative to the pool size (ie, it significantly moves the price). It is recommended that the pDAO place a large amount of protocol-owned liquidity in the pool to begin with. This liquidity can be removed once the "Buy & LP" process has built up size sufficiently.
-- Some resources for Balancer weighted pools: https://docs.balancer.fi/concepts/pools/weighted.html, https://docs.balancer.fi/reference/math/weighted-math.html, and https://balancer.fi/whitepaper.pdf. If using this solution, some math should be done to understand what size pool and threshold make sense to avoid significant value extraction.
+- Some resources for Balancer weighted pools: https://docs.balancer.fi/concepts/pools/weighted.html, https://docs.balancer.fi/reference/math/weighted-math.html, and https://docs.balancer.fi/whitepaper.pdf. If using this solution, some math should be done to understand what size pool and threshold make sense to avoid significant value extraction.
 - The upgradable contract allows flexibility such as, but not limited to:
   - A new pool could be targeted
   - A gradual migration from a previously targeted pool to the current target (eg, an "all-asset" withdrawal followed by an "all-asset" deposit plus a single-asset deposit); this approach could reduce the amount of idle ETH by moving to a pool with greater RPL weight


### PR DESCRIPTION
Hi! I updated a broken link in `RPIP-50.md`. The outdated reference to `https://balancer.fi/whitepaper.pdf` has been corrected to `https://docs.balancer.fi/whitepaper.pdf` to ensure accuracy and accessibility.
