### PR TITLE
Finalize RPIP-70

### DIFF
--- a/RPIPs/RPIP-70.md
+++ b/RPIPs/RPIP-70.md
@@ -1,10 +1,10 @@
 ---
 rpip: 70
 Title: Ronin Bridge Info
-description: Describing Ronin
+description: Describing Ronin Bridge
 author: Valdorff (@Valdorff)
-discussions-to:
-status: Review
+discussions-to: N/A
+status: Final
 type: Info
 created: 2024-04-14
 requires:
@@ -23,13 +23,13 @@ This document is meant to record how the Ronin bridge is being deployed.
    2. LockReleaseTokenPool on mainnet holds crosschain bridged rETH
    3. BurnMintTokenPool on Ronin burns/mints rETH bridged to Ronin
 2. Ownership of the RETH token on Ronin will be burnt after assigning mint rights to the TokenPool. This is in line with the immutable tokens we've used on L2s.
-3. Ownership of the LockReleaseTokenPool and  BurnMintTokenPool will remain with Chainlink. This is in line with upgradable native bridges we've used on L2s.
+3. Chainlink will retain ownership of the LockReleaseTokenPool and  BurnMintTokenPool. This is in line with upgradable native bridges we've used on L2s.
    1. Chainlink is willing to transfer ownership at any time at the request of the Rocket Pool pDAO (via governance vote)
 
 Note, there is a separate RPIP related to fees when using this bridge.
 
 ## Security considerations
-It's worth to note that the analogy to L2 native bridges is imperfect:
+It's worth noting that the analogy to L2 native bridges is imperfect:
 - Users should be aware that Ronin is not an L2 and will not have "escape hatches" to mainnet as a result
 - Users should be aware that they are trusting two separate entities to secure their bridged tokens
   - Ronin to secure the chain


### PR DESCRIPTION
- Grammarly
- discussions-to link set to N/A in header; discord and forum had bits of it, but there was no good single resource
- Fix description in header
- Set to final