### PR TITLE
RPIP-70 - fixed title and made type consistent

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,7 +21,6 @@ GEM
       http_parser.rb (~> 0)
     ethon (0.16.0)
       ffi (>= 1.15.0)
-    eventmachine (1.2.7)
     eventmachine (1.2.7-x64-mingw32)
     execjs (2.9.1)
     faraday (2.7.11)
@@ -29,7 +28,6 @@ GEM
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (3.0.2)
-    ffi (1.15.5)
     ffi (1.15.5-x64-mingw32)
     forwardable-extended (2.6.0)
     gemoji (3.0.1)
@@ -216,15 +214,11 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.3.6)
-    mini_portile2 (2.8.9)
     minima (2.5.1)
       jekyll (>= 3.5, < 5.0)
       jekyll-feed (~> 0.9)
       jekyll-seo-tag (~> 2.1)
     multi_json (1.15.0)
-    nokogiri (1.15.4)
-      mini_portile2 (~> 2.8.2)
-      racc (~> 1.4)
     nokogiri (1.15.4-x64-mingw32)
       racc (~> 1.4)
     octokit (4.25.1)
@@ -264,15 +258,14 @@ GEM
       tzinfo (>= 1.0.0)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.8.2)
     unf_ext (0.0.8.2-x64-mingw32)
     unicode-display_width (1.8.0)
+    wdm (0.1.1)
     webrick (1.8.1)
     yell (2.2.2)
     zeitwerk (2.6.11)
 
 PLATFORMS
-  ruby
   x64-mingw32
 
 DEPENDENCIES
@@ -281,6 +274,7 @@ DEPENDENCIES
   jekyll-feed (~> 0.11)
   minima (~> 2.0)
   tzinfo-data
+  wdm (~> 0.1.0)
   webrick (~> 1.8)
 
 BUNDLED WITH

--- a/RPIPs/RPIP-70.md
+++ b/RPIPs/RPIP-70.md
@@ -1,11 +1,11 @@
 ---
 rpip: 70
-Title: Ronin Bridge Info
+title: Ronin Bridge Info
 description: Describing Ronin Bridge
 author: Valdorff (@Valdorff)
 discussions-to: N/A
 status: Final
-type: Info
+type: Informational
 created: 2024-04-14
 requires:
 ---


### PR DESCRIPTION
The title was showing up like this:
![image](https://github.com/user-attachments/assets/550d5ffd-9c68-406d-9c60-ca226956b55a)

Fixed a typo in the metadata and changed the type to be consistent with other RPIPs, while I was there.