### PR TITLE
Updated values for RPIP-81 and added previous changes that were never recorded

### DIFF
--- a/RPIPs/RPIP-10.md
+++ b/RPIPs/RPIP-10.md
@@ -192,6 +192,8 @@ roughly steady given the initial proposed inflation step.
 | 2022-08-09<br>(ratified 2022-08-24) | Incentives (e.g., LP bonuses) - 50%, Grants and Bounties - 30%, Reserve Treasury - 20%     |
 | 2023-07-17                          | Incentives (e.g., LP bonuses) - 27%, Grants and Bounties - 16%, Reserve Treasury - 57%     |
 | 2023-11-16                          | Incentives (e.g., LP bonuses) - 50%, Grants and Bounties - 20.5%, Reserve Treasury - 29.5% |
+| 2025-04-27                          | Incentives (e.g., LP bonuses) - 50%, Grants and Bounties - 25%, Reserve Treasury - 25% |
+| 2026-07-10                          | Incentives (e.g., LP bonuses) - 30%, Grants and Bounties - 40%, Reserve Treasury - 30% |
 
 ## pDAO Treasurer History
 

--- a/RPIPs/RPIP-10.md
+++ b/RPIPs/RPIP-10.md
@@ -26,9 +26,9 @@ changes to how the funds should be directed.
 
 ## Specification
 - Incoming funds SHALL be tracked and apportioned per category with the following split:
-  - Incentives (e.g., LP bonuses) - 50%
-  - Grants and Bounties - 20.5%
-  - Reserve Treasury - 29.5%
+  - Incentives (e.g., LP bonuses) - 30%
+  - Grants and Bounties - 40%
+  - Reserve Treasury - 30%
 - Where a matching Management Committee exists (eg, the "Incentives Management Committee" for the "Incentives"
   category), incoming funds SHALL be disbursed to the matching Management Committee as quickly as practical.
   - When possible, automation SHOULD be used to facilitate and expedite disbursements.

--- a/RPIPs/RPIP-25.md
+++ b/RPIPs/RPIP-25.md
@@ -4,7 +4,7 @@ title: RPL Inflation Allocation
 description: Describes the planned usage of RPL inflation
 author: jasperthegovghost (@jasperthefriendlyghost), Valdorff (@Valdorff)
 discussions-to: https://dao.rocketpool.net/t/odao-charter-draft-and-more/1832
-status: Final
+status: Living
 type: Meta
 created: 2023-06-02
 vote-to: https://vote.rocketpool.net/#/proposal/0x510383ca82a0096fa670a260692cf7a4097e199ce4f731dc4efd97a21f19f988
@@ -80,6 +80,8 @@ update this RPIP:
 | Date         | Allocation                                                                                                      |
 |--------------|-----------------------------------------------------------------------------------------------------------------|
 | 2021-09-30   | Node Operators (`rocketClaimNode`) - 70%, pDAO (`rocketClaimDAO`) - 15%, oDAO (`rocketClaimTrustedNode`) - 15%  |
+| 2025-03-24   | Node Operators (`rocketClaimNode`) - 70%, pDAO (`rocketClaimDAO`) - 27.5%, oDAO (`rocketClaimTrustedNode`) - 2.5%  |
+| 2026-07-10   | Node Operators (`rocketClaimNode`) - 50%, pDAO (`rocketClaimDAO`) - 47.5%, oDAO (`rocketClaimTrustedNode`) - 2.5%  |
 
 ## Copyright
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/RPIPs/RPIP-25.md
+++ b/RPIPs/RPIP-25.md
@@ -23,16 +23,17 @@ many purposes, which can change over time, so this RPIP will be a Living documen
 changes to how the funds should be directed.
 
 ## Specification
-1. If the RPIP is approved, inflation SHALL be set to:
-   1. Node Operators (`rocketClaimNode`) - 70%
-   2. pDAO (`rocketClaimDAO`) - 22%
-   3. oDAO (`rocketClaimTrustedNode`) - 8%
-2. 2 reward periods after `1.`, pDAO and oDAO allocations SHALL be set to 23%/7% respectively. 
-3. 2 reward periods after `2.`, pDAO and oDAO allocations SHALL be set to 24.1%/5.9% respectively.
-4. 2 reward periods after `3.`, pDAO and oDAO allocations SHALL be set to 25.2%/4.8% respectively.
-5. 2 reward periods after `4.`, pDAO and oDAO allocations SHALL be set to 26.3%/3.7% respectively.
-6. 2 reward periods after `5.`, pDAO and oDAO allocations SHALL be set to 27.4%/2.6% respectively.
-7. 2 reward periods after `6.`, pDAO and oDAO allocations SHALL be set to 28.5%/1.5% respectively.
+The current RPL inflation allocation is:
+
+- Node Operators (`rocketClaimNode`) - 50%
+- pDAO (`rocketClaimDAO`) - 47.5%
+- oDAO (`rocketClaimTrustedNode`) - 2.5%
+
+After Saturn 2, RPL inflation allocation SHALL be set to:
+
+- Node Operators (`rocketClaimNode`) - 0%
+- pDAO (`rocketClaimDAO`) - 95%
+- oDAO (`rocketClaimTrustedNode`) - 5%
 
 ### Updating this RPIP
 This is a "Living" RPIP, so that it can be kept up to date with changes to Inflation Allocation.
@@ -80,8 +81,21 @@ update this RPIP:
 | Date         | Allocation                                                                                                      |
 |--------------|-----------------------------------------------------------------------------------------------------------------|
 | 2021-09-30   | Node Operators (`rocketClaimNode`) - 70%, pDAO (`rocketClaimDAO`) - 15%, oDAO (`rocketClaimTrustedNode`) - 15%  |
+| 2023-11-14   | RPIP-25 approved a staged transition* from 70% Node Operators / 22% pDAO / 8% oDAO to 70% Node Operators / 28.5% 
 | 2025-03-24   | Node Operators (`rocketClaimNode`) - 70%, pDAO (`rocketClaimDAO`) - 27.5%, oDAO (`rocketClaimTrustedNode`) - 2.5%  |
 | 2026-07-10   | Node Operators (`rocketClaimNode`) - 50%, pDAO (`rocketClaimDAO`) - 47.5%, oDAO (`rocketClaimTrustedNode`) - 2.5%  |
+
+*RPIP-25 originally specified the following staged pDAO/oDAO allocation changes, while keeping Node Operators at 70%:
+
+| Transition | Timing | Node Operators | pDAO | oDAO |
+|------------|--------|----------------|------|------|
+| 0 | Initial | 70% | 22% | 8% |
+| 1 | 2 reward periods later | 70% | 23% | 7% |
+| 2 | 2 reward periods later | 70% | 24.1% | 5.9% |
+| 3 | 2 reward periods later | 70% | 25.2% | 4.8% |
+| 4 | 2 reward periods later | 70% | 26.3% | 3.7% |
+| 5 | 2 reward periods later | 70% | 27.4% | 2.6% |
+| 6 | 2 reward periods later | 70% | 28.5% | 1.5% |
 
 ## Copyright
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/RPIPs/RPIP-46.md
+++ b/RPIPs/RPIP-46.md
@@ -91,7 +91,7 @@ Prior to the release of Saturn 1, a ranked-choice vote MUST be held to select a 
 ## Specification taking effect with Saturn 2
 ### RPL issuance rewards and inflation
 1. Inflation settings SHALL be modified to retain inflation to the DAOs and eliminate inflation to node operators
-   1. `rpl.inflation.interval.rate` SHALL be set to `1000067606974065369` (2.5% per year)
+   1. `rpl.inflation.interval.rate` SHALL be set to `1000040763630249500` (1.5% per year)
    2. Node operators (`rocketClaimNode`) allocation SHALL be set to 0%
    3. pDAO (`rocketClaimDAO`) allocation SHALL be set to 95%
    4. oDAO (`rocketClaimTrustedNode`) allocation SHALL be set to 5%

--- a/RPIPs/RPIP-46.md
+++ b/RPIPs/RPIP-46.md
@@ -91,7 +91,7 @@ Prior to the release of Saturn 1, a ranked-choice vote MUST be held to select a 
 ## Specification taking effect with Saturn 2
 ### RPL issuance rewards and inflation
 1. Inflation settings SHALL be modified to retain inflation to the DAOs and eliminate inflation to node operators
-   1. `rpl.inflation.interval.rate` SHALL be set to `1000040763630249500` (1.5% per year)
+   1. `rpl.inflation.interval.rate` SHALL be set to `1000067606974065369` (2.5% per year)
    2. Node operators (`rocketClaimNode`) allocation SHALL be set to 0%
    3. pDAO (`rocketClaimDAO`) allocation SHALL be set to 95%
    4. oDAO (`rocketClaimTrustedNode`) allocation SHALL be set to 5%


### PR DESCRIPTION
RPIP-81 has passed Snapshot and on-chain implementation. This PR updates living RPIPs that describe current or future RPL inflation and pDAO allocation values so they no longer reference superseded numbers. In addition, this adds previous changes that were voted in and enacted, but never recorded.

I also changed the status of RPIP-25 from "Final" to "Living" since it seems it is supposed to be (and refers to itself) as a living RPIP. Reject that change if it is not appropriate.

Finally, still consistent with RPIP-81, the RPL inflation in RPIP-46 is updated using the same formula as used for 1.5% inflation ( (1 + inflation_rate) ** (1 / 365.25) * 1e18 ). Although RPIP-46 says it is "Living", it was not clear whether this should only apply to the table at the bottom with commission share values or if it applied to all parts of the document. I included the inflation update as if the entire document is living.

